### PR TITLE
Add significant figure support to write_nblock

### DIFF
--- a/mapdl_archive/archive.py
+++ b/mapdl_archive/archive.py
@@ -243,6 +243,7 @@ def save_as_archive(
     include_solid_elements=True,
     include_components=True,
     exclude_missing=False,
+    node_sig_digits=13,
 ):
     """Write FEM as an ANSYS APDL archive file.
 
@@ -327,6 +328,10 @@ def save_as_archive(
         nodes. This allows you to exclude midside nodes for certain element
         types (e.g. ``SOLID186``). Missing midside nodes are identified as
         ``-1`` in the ``"ansys_node_num"`` array.
+
+    node_sig_digits : int, default: 13
+        Number of significant digits to use when writing the nodes. Must be
+        greater than 0.
 
     Examples
     --------
@@ -587,9 +592,12 @@ def save_as_archive(
             nodenum[~missing_mask],
             grid.points[~missing_mask],
             mode="a",
+            sig_digits=node_sig_digits,
         )
     else:
-        write_nblock(filename, nodenum, grid.points, mode="a")
+        write_nblock(
+            filename, nodenum, grid.points, mode="a", sig_digits=node_sig_digits
+        )
 
     # write remainder of eblock
     _write_eblock(

--- a/mapdl_archive/cython/_archive.pyx
+++ b/mapdl_archive/cython/_archive.pyx
@@ -58,7 +58,7 @@ def py_write_nblock(filename, const int [::1] node_id, int max_node_id,
         File open mode. Default is 'w' (write), other options include 'a' (append).
 
     sig_digits : int, default: 13
-        Number of significant digits to use when writing the node data. Default is 13.
+        Number of significant digits to use when writing the nodes.
 
     Raises
     ------
@@ -115,7 +115,7 @@ def py_write_nblock_float(filename, const int [::1] node_id, int max_node_id,
         File open mode. Default is 'w' (write), other options include 'a' (append).
 
     sig_digits : int, default: 13
-        Number of significant digits to use when writing the node data. Default is 13.
+        Number of significant digits to use when writing the nodes.
 
     Raises
     ------

--- a/mapdl_archive/cython/reader.c
+++ b/mapdl_archive/cython/reader.c
@@ -19,7 +19,7 @@ static const double DIV_OF_TEN[] = {
     1.0e-0,  1.0e-1,  1.0e-2,  1.0e-3,  1.0e-4,  1.0e-5,  1.0e-6,
     1.0e-7,  1.0e-8,  1.0e-9,  1.0e-10, 1.0e-11, 1.0e-12, 1.0e-13,
     1.0e-14, 1.0e-15, 1.0e-16, 1.0e-17, 1.0e-18, 1.0e-19, 1.0e-20,
-    1.0e-21, 1.0e-22, 1.0e-23, 1.0e-24,
+    1.0e-21, 1.0e-22, 1.0e-23, 1.0e-24, 1.0e-25, 1.0e-26, 1.0e-27,
 };
 
 static inline double power_of_ten(int exponent) {
@@ -112,7 +112,7 @@ static inline int ans_strtod(char *raw, int fltsz, double *arr) {
 
   // Compute the floating-point value
   double val;
-  if (decimal_digits < 24) {
+  if (decimal_digits < 27) {
     val = (double)val_int * DIV_OF_TEN[decimal_digits];
   } else {
     val = (double)val_int * power_of_ten(10);
@@ -137,21 +137,10 @@ static inline int ans_strtod(char *raw, int fltsz, double *arr) {
       }
       evalue = evalue * 10 + (*raw++ - '0');
     }
-    // printf("%d\n", evalue);
-    // val *= pow10(evalue);
     if (esign == 1) {
       val *= power_of_ten(evalue);
-
-      // while (evalue > 0) {  // raises value to the power of the exponent
-      //   val *= 10;
-      //   evalue--;
-      // }
     } else {
       val /= power_of_ten(evalue);
-      // while (evalue > 0) {
-      //   val *= 0.1;
-      //   evalue--;
-      // }
     }
   }
 
@@ -161,7 +150,6 @@ static inline int ans_strtod(char *raw, int fltsz, double *arr) {
   } else {
     *arr = val;
   }
-  /* printf(", %f", val); */
 
   return 0; // Return 0 when a number has a been read
 }
@@ -319,8 +307,8 @@ int read_nblock_from_nwrite(const char *filename, int *nnum, double *nodes,
   }
 
   // set to start of the NBLOCK
-  const int bufsize = 74; // One int, 3 floats, two end char max (/r/n)
-  char buffer[74];
+  const int bufsize = 150;
+  char buffer[150];
   int i;
 
   for (i = 0; i < nnodes; i++) {

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -481,6 +481,26 @@ def test_write_nblock(hex_archive, tmpdir, dtype, has_angles):
         assert np.allclose(hex_archive.node_angles, tmp_archive.node_angles)
 
 
+@pytest.mark.parametrize("sig_digits", [8, 18])
+def test_write_nblock_sig_digits(hex_archive, tmpdir, sig_digits):
+    nblock_filename = str(tmpdir.mkdir("tmpdir").join("nblock.inp"))
+
+    nodes = hex_archive.nodes
+    angles = hex_archive.node_angles
+    with pytest.raises(ValueError, match="sig_digits"):
+        archive.write_nblock(
+            nblock_filename, hex_archive.nnum, nodes, angles, sig_digits=-1
+        )
+
+    archive.write_nblock(
+        nblock_filename, hex_archive.nnum, nodes, angles, sig_digits=sig_digits
+    )  # more than 18 fails
+    tmp_archive = Archive(nblock_filename)
+    assert np.allclose(hex_archive.nnum, tmp_archive.nnum)
+    assert np.allclose(hex_archive.nodes, tmp_archive.nodes)
+    assert np.allclose(hex_archive.node_angles, tmp_archive.node_angles)
+
+
 def test_cython_write_eblock(hex_archive, tmpdir):
     filename = str(tmpdir.mkdir("tmpdir").join("eblock.inp"))
 


### PR DESCRIPTION
Support the configuration of the number of signifiant figures when writing the node blocks of archive files.
