### PR TITLE
Add py.typed

### DIFF
--- a/mapdl_archive/py.typed
+++ b/mapdl_archive/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/setup.py
+++ b/setup.py
@@ -77,11 +77,12 @@ setup(
     python_requires=">=3.8",
     keywords="vtk MAPDL ANSYS cdb",
     package_data={
+        "mapdl_archive": ["py.typed"],
         "mapdl_archive.examples": [
             "TetBeam.cdb",
             "HexBeam.cdb",
             "sector.cdb",
-        ]
+        ],
     },
     install_requires=["pyvista>=0.41.1"],
 )


### PR DESCRIPTION
Distribute typing by adding `py.typed` according to [PEP 561](https://peps.python.org/pep-0561/).