### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -105,32 +105,27 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-  Release:
+  release:
+    name: Release
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build, mac_build]
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mapdl-archive
+    permissions:
+      id-token: write  # this permission is mandatory for trusted publishing
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
-      # this downloads all artifacts
       - uses: actions/download-artifact@v3
-
       - name: Display structure of downloaded files
         run: ls -R
-
-      - name: Upload to Public PyPi
+      - name: Move wheels to dist
         run: |
-          pip install twine
-          twine upload --skip-existing ./**/*.whl
-          twine upload --skip-existing ./**/*.tar.gz
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-
-      - name: Release
+          mkdir -p dist/
+          find . -name "*.whl" -exec mv {} dist/ \;
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: true


### PR DESCRIPTION
Use trusted publishing following the directions from [PyPI publish GitHub Action](https://github.com/pypa/gh-action-pypi-publish#pypi-publish-github-action).