### PR TITLE
give mac-os artifacts a name and include tarball

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -104,10 +104,11 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: mapdl-archive-wheel-${{ matrix.os }}
 
   release:
     name: Release
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build, mac_build]
     runs-on: ubuntu-latest
     environment:
@@ -119,15 +120,16 @@ jobs:
       - uses: actions/download-artifact@v4
       - name: Display structure of downloaded files
         run: ls -R
-      - name: Move wheels to dist
+      - name: Flatten directory structure
         run: |
           mkdir -p dist/
-          find . -name "*.whl" -exec mv {} dist/ \;
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            ./**/*.whl
+          find . -name '*.whl' -exec mv {} dist/ \;
+          find . -name '*.tar.gz' -exec mv {} dist/ \;
+      # - name: Publish package distributions to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      # - name: Create GitHub Release
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     generate_release_notes: true
+      #     files: |
+      #       ./**/*.whl


### PR DESCRIPTION
v4 of upload and download artifact requires some minor changes for the CI.

- [ ] Don't merge until verifying structure of the downloaded files.
