### PR TITLE
Release v0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ description = "Pythonic interface to MAPDL archive files."
 name = "mapdl-archive"
 readme = "README.rst"
 requires-python = ">=3.8"
-version = "0.2.dev0"
+version = "0.3.dev0"
 
 [project.urls]
 Repository = "https://github.com/akaszynski/mapdl-archive"


### PR DESCRIPTION
Bump to `v0.3.0` in preparation for releasing `v0.2.0`.
