### PR TITLE
add write permission for release step

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -68,6 +68,7 @@ jobs:
       url: https://pypi.org/p/mapdl-archive
     permissions:
       id-token: write  # this permission is mandatory for trusted publishing
+      contents: write
     steps:
     - uses: actions/download-artifact@v4
     - name: Flatten directory structure


### PR DESCRIPTION
https://github.com/akaszynski/mapdl-archive/actions/runs/11847306836/job/33016880001 failed due to missing permissions on the release step. Add it in this PR.
