### PR TITLE
Require manylinux2014 for x86

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -13,18 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  style:
-    name: Check Style
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v6
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.14'
-    - uses: pre-commit/action@v3.0.1
-      env:
-        SKIP: no-commit-to-branch
 
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -13,6 +13,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  style:
+    name: Check Style
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.14'
+    - uses: pre-commit/action@v3.0.1
+      env:
+        SKIP: no-commit-to-branch
+
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -20,13 +33,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, windows-2025, macos-latest, macos-15-intel, ubuntu-24.04-arm]
-
     steps:
     - uses: actions/checkout@v6
-
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.3.1
-
     - uses: actions/upload-artifact@v6
       with:
         name: mapdl-archive-wheels-${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.2
+  rev: v0.15.5
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -19,7 +19,7 @@ repos:
     exclude: README.rst
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.4.1
+  rev: v2.4.2
   hooks:
   - id: codespell
     args: [--skip=*.vt*]
@@ -38,6 +38,8 @@ repos:
   - id: debug-statements
   - id: trailing-whitespace
     exclude: .*\.(cdb|rst|dat)$
+  - id: no-commit-to-branch
+    args: [--branch, main]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.19.1
@@ -55,12 +57,12 @@ repos:
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v21.1.8
+  rev: v22.1.1
   hooks:
   - id: clang-format
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.36.2
+  rev: 0.37.0
   hooks:
   - id: check-github-workflows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ test-command = "pytest {project}/tests -vv"
 test-extras = ["tests"]
 
 [tool.cibuildwheel.linux]
+manylinux-aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux2014"
 repair-wheel-command = [
   "auditwheel repair -w {dest_dir} {wheel}",
   "bash tools/audit_wheel.sh {wheel}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ test-command = "pytest {project}/tests -vv"
 test-extras = ["tests"]
 
 [tool.cibuildwheel.linux]
-manylinux-aarch64-image = "manylinux2014"
 manylinux-x86_64-image = "manylinux2014"
 repair-wheel-command = [
   "auditwheel repair -w {dest_dir} {wheel}",


### PR DESCRIPTION
Use the `manylinux2014` image when building wheels for x86 (`vtk` for ARM requires `glibc 2.28+` . Also:
- Update `pre-commit` and add `no-commit-to-branch`.